### PR TITLE
Remove 'futures' from installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='mwscrape',
       license='MPL 2.0',
       packages=['mwscrape'],
       #mwclient appears to need six, but doesn't declare it as dependency
-      install_requires=['futures', 'CouchDB >= 0.10', 'mwclient >= 0.10.0', 'pylru'],
+      install_requires=['CouchDB >= 0.10', 'mwclient >= 0.10.0', 'pylru'],
       entry_points={'console_scripts': [
           'mwscrape=mwscrape.scrape:main',
           'mwresolvec=mwscrape.resolveconflicts:main',


### PR DESCRIPTION
Since Python 3 includes concurrent.futures in the standard library, this dependency is unnecessary and has been removed.