### PR TITLE
Replace deprecated datetime.utcnow() with timezone-aware datetime

### DIFF
--- a/mwscrape/scrape.py
+++ b/mwscrape/scrape.py
@@ -336,7 +336,7 @@ def main():
         site_host = session_doc["site"]
         scheme, host = scheme_and_host(site_host)
         db_name = session_doc["db_name"]
-        session_doc["resumed_at"] = datetime.utcnow().isoformat()
+        session_doc["resumed_at"] = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
         if args.start:
             start_page_name = args.start
         else:
@@ -429,7 +429,7 @@ def main():
     elif args.changes_since or args.recent:
         if args.recent:
             recent_days = args.recent_days
-            changes_since = fmt_mw_tms(datetime.utcnow() + timedelta(days=-recent_days))
+            changes_since = fmt_mw_tms(datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=-recent_days))
         else:
             changes_since = args.changes_since.ljust(14, "0")
         print("Getting recent changes (since %s)" % changes_since)

--- a/mwscrape/scrape.py
+++ b/mwscrape/scrape.py
@@ -19,7 +19,7 @@ import urllib.parse
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from multiprocessing import RLock
 from multiprocessing.pool import ThreadPool
 from contextlib import contextmanager
@@ -362,7 +362,7 @@ def main():
         )
         print("Starting session %s" % session_id)
         sessions_db[session_id] = {
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "site": site_host,
             "db_name": db_name,
             "descending": descending,
@@ -458,7 +458,7 @@ def main():
         with lock:
             session_doc = sessions_db[session_id]
             session_doc["last_page_name"] = title
-            session_doc["updated_at"] = datetime.utcnow().isoformat()
+            session_doc["updated_at"] = datetime.now(timezone.utc).isoformat()
             sessions_db[session_id] = session_doc
 
     def process(page):


### PR DESCRIPTION
- Updated all occurrences of datetime.utcnow() to datetime.now(timezone.utc) to comply with modern Python standards and avoid DeprecationWarning.
`DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). session_doc["updated_at"] = datetime.utcnow().isoformat()`
- Added `timezone` to datetime imports where missing.
- Ensures created_at and updated_at fields are now timezone-aware UTC datetimes.
- Maintains compatibility with Python >=3.2.